### PR TITLE
Fix chapter loops to be memory-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.01.08
+- Chapter loops are managed differently now, they wont be stored in DB.
+  - This will solve an issue that YouTube Looper was creating entries even without the user interacting with the looper.
+  - It also fixes potential cases where YouTube Looper might create loops from chapters from a different video.
+  - It also improves the situation where the chapters might change, being only in-memory will make them always current.
+
 ## 2026.01.04
 - Fix button insertion when using with YouTube embed player
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026.01.08
+## 2026.1.8
 - Chapter loops are managed differently now, they wont be stored in DB.
   - This will solve an issue that YouTube Looper was creating entries even without the user interacting with the looper.
   - It also fixes potential cases where YouTube Looper might create loops from chapters from a different video.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "youtube-looper",
   "description": "Custom loops extension for Youtube videos",
   "private": true,
-  "version": "2026.01.04",
+  "version": "2026.01.08",
   "scripts": {
     "dev": "wxt",
     "dev:firefox": "wxt -b firefox",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "youtube-looper",
   "description": "Custom loops extension for Youtube videos",
   "private": true,
-  "version": "2026.01.08",
+  "version": "2026.1.8",
   "scripts": {
     "dev": "wxt",
     "dev:firefox": "wxt -b firefox",

--- a/src/lib/components/ActiveLoop.svelte
+++ b/src/lib/components/ActiveLoop.svelte
@@ -4,15 +4,18 @@
   import type {Id} from "tinybase";
   import type {Loop} from "@/lib/model";
 
-  let {video = document.querySelector("video"), id}: {
+  let {video = document.querySelector("video"), id, loop: loopProp}: {
     video?: HTMLVideoElement | null,
-    id: Id
+    id: Id,
+    loop?: Loop
   } = $props()
 
   const store = getTinyContextForce('store')
 
-  let loopStore = $derived(useRow<Loop>(store, 'loops', id))
-  let loop = $derived($loopStore)
+  // Only use prop data for readonly loops (memory-only chapter loops)
+  // For persisted loops, always load from TinyBase to get reactive updates
+  let loopStore = $derived(loopProp?.readonly ? undefined : useRow<Loop>(store, 'loops', id))
+  let loop = $derived((loopProp?.readonly ? loopProp : $loopStore) as Loop)
   let startTime = $derived(loop.startTime)
 
   let duration = $derived(video?.duration as number)

--- a/src/lib/components/LoopsController.svelte
+++ b/src/lib/components/LoopsController.svelte
@@ -64,10 +64,6 @@
           }
         })
 
-        if (loops.length > 0) {
-          ensureMediaInfo()
-        }
-
         // Store chapter loops in memory only
         const chaptersMap: {[key: Id]: Loop} = {}
         for (const {id, ...loop} of loops) {
@@ -152,7 +148,10 @@
     where('source', sourceId)
   }))
 
-  let loops = $derived($loopsContainer)
+  // Filter out readonly loops (they're now loaded in memory only from chapters)
+  let loops = $derived(Object.fromEntries(
+    Object.entries($loopsContainer).filter(([_, loop]) => loop.readonly !== true)
+  ))
 
   // Merge chapter loops (in-memory only) with persisted loops from store
   let mergedLoops = $derived({...chapterLoops, ...loops})

--- a/src/lib/components/Youtube.svelte
+++ b/src/lib/components/Youtube.svelte
@@ -42,6 +42,9 @@
   let controllerComponent: LoopsController | undefined = $state()
   let jumpBackComponent: JumpBack | undefined = $state();
 
+  // Get loop data from controller (includes both persisted and memory-only chapter loops)
+  let activeLoopData = $derived(activeLoop && controllerComponent ? controllerComponent.getLoop(activeLoop) : undefined)
+
   function log(event: string, details?: {[key: string]: any}) {
     trackEvent(event, {
       source_id: sourceId,
@@ -50,7 +53,9 @@
   }
 
   function loopLogDetail(loopId: Id) {
-    return {label: ctx.store.getCell('loops', loopId, 'label')}
+    // Try to get from controller (includes memory-only loops), fallback to store
+    const loop = controllerComponent?.getLoop(loopId)
+    return {label: loop?.label || ctx.store.getCell('loops', loopId, 'label')}
   }
 
   function toggleVisible() {
@@ -154,7 +159,7 @@
     </button>
 
     {#if activeLoop}
-      <ActiveLoop id={activeLoop} bind:this={activeComponent}/>
+      <ActiveLoop id={activeLoop} loop={activeLoopData} bind:this={activeComponent}/>
     {/if}
 
       <div class="ytp-popup ytp-settings-menu ml-popup" use:portal={{target: ".html5-video-player"}} style="display: {popupVisible ? 'block' : 'none'}">

--- a/src/lib/misc/loop-tree.ts
+++ b/src/lib/misc/loop-tree.ts
@@ -19,11 +19,14 @@ function iterateBreak([first, ...rest]: Loops): Loops {
       }
     }
 
+    // Create a new loop object instead of mutating the original
+    const newFirst: LoopEntry = [first[0], {...first[1]}]
+
     if (separation >= 0) {
-      first[1].children = iterateBreak(rest.slice(0, separation + 1))
+      newFirst[1].children = iterateBreak(rest.slice(0, separation + 1))
     }
 
-    return [first, ...iterateBreak(rest.slice(separation + 1))]
+    return [newFirst, ...iterateBreak(rest.slice(separation + 1))]
   } else {
     return []
   }


### PR DESCRIPTION
## Summary
- Implement memory-only chapter loops that don't persist to database
- Add cleanup routine to remove previously persisted chapter loops
- Fix all components to support memory-only loop data
- Clear chapter loops when navigating between videos

## Changes
- **LoopsController**: Store chapter loops in memory only, filter out readonly loops from persisted store
- **DashboardWrapper**: Add cleanup routine to remove readonly loops from database on mount
- **LoopEntry & ActiveLoop**: Accept optional loop prop for memory-only loops while maintaining reactive updates for persisted loops
- **loop-tree**: Fix state mutation in derived expressions by creating new objects

## Test plan
- [x] Chapter loops load and display correctly
- [x] Playing chapter loops works without database access
- [x] Persisted loops maintain reactive updates when edited
- [x] Chapter loops clear when navigating to different video
- [x] Duplicating chapter loops creates persisted copy
- [x] Previously persisted chapter loops are cleaned up