### PR TITLE
Fix YouTube embed error in dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026.1.9
+- Fix YouTube embed error in dashboard
+  - Removed modal video preview that was causing YouTube Error 153
+  - Clicking video thumbnails now opens videos directly in YouTube in a new tab
+  - Provides better user experience while avoiding Chrome extension embedding limitations
+
 ## 2026.1.8
 - Chapter loops are managed differently now, they wont be stored in DB.
   - This will solve an issue that YouTube Looper was creating entries even without the user interacting with the looper.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "youtube-looper",
   "description": "Custom loops extension for Youtube videos",
   "private": true,
-  "version": "2026.1.8",
+  "version": "2026.1.9",
   "scripts": {
     "dev": "wxt",
     "dev:firefox": "wxt -b firefox",

--- a/src/entrypoints/dashboard/components/Dashboard.svelte
+++ b/src/entrypoints/dashboard/components/Dashboard.svelte
@@ -5,7 +5,6 @@
   import {download, pickFile, readFileText} from "@/lib/misc/browser-file";
   import MediaAdmin from "@/entrypoints/dashboard/components/MediaAdmin.svelte";
   import type {Media} from "@/lib/model";
-  import YoutubeEmbed from "@/lib/components/YoutubeEmbed.svelte";
   import ImportEntry from "@/entrypoints/dashboard/components/ImportEntry.svelte";
   import {channelListener, runtimeOnMessageListener} from "@/lib/misc/browser-network";
   import deburr from "lodash/deburr";
@@ -15,7 +14,6 @@
 
   const store = getTinyContextForce('store') as MergeableStore
 
-  let media: string | false = $state(false)
   let search = $state("")
   let toImport: { [key: string]: any } | false = $state(false)
 
@@ -97,18 +95,10 @@
     </TableHead>
     <TableBody tableBodyClass="divide-y">
       {#each ids as id (id)}
-        <MediaAdmin {id} on:click={() => media = id}/>
+        <MediaAdmin {id} />
       {/each}
     </TableBody>
   </TableSearch>
-
-  <Modal bind:open={media} autoclose outsideclose dismissable={false} size={'xl'} classDialog="outline-0">
-    {#if media}
-      <YoutubeEmbed videoId={media.substring(8)} />
-    {:else}
-      <div>Something is wrong, no media selected.</div>
-    {/if}
-  </Modal>
 
   <Modal title="Import medias" bind:open={toImport} autoclose outsideclose classDialog="outline-0">
     <div class="flex flex-row flex-wrap justify-between">

--- a/src/entrypoints/dashboard/components/MediaAdmin.svelte
+++ b/src/entrypoints/dashboard/components/MediaAdmin.svelte
@@ -31,7 +31,7 @@
 
   </script>
 
-<TableBodyRow on:click>
+<TableBodyRow>
   <TableBodyCell class="min-w-[120px]">
     <A href="https://www.youtube.com/watch?v={videoId}" target="_blank" on:click={sp}>
       <img src={getThumbUrl(videoId, 'default')} alt="{$media.title}" />

--- a/src/lib/components/YoutubeEmbed.svelte
+++ b/src/lib/components/YoutubeEmbed.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import {getThumbUrl} from "@/lib/helpers/youtube";
+  import {PlaySolid} from "flowbite-svelte-icons";
 
   let {videoId, ...props}: {
     videoId: string,
@@ -7,14 +9,23 @@
 
   let clazz = $derived(props.class || '')
 
+  function openVideo() {
+    window.open(`https://www.youtube.com/watch?v=${videoId}`, '_blank');
+  }
 </script>
 
-<div class="w-full pb-[56.25%] relative flex-1 ${clazz}">
-  <iframe
-      class="left-0 top-0 w-full h-full absolute"
-      src="https://www.youtube.com/embed/{videoId}"
-      title="YouTube video player"
-      frameborder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-      referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div class="w-full pb-[56.25%] relative flex-1 ${clazz} cursor-pointer group" onclick={openVideo}>
+  <img
+    src={getThumbUrl(videoId, 'maxresdefault')}
+    alt="Video thumbnail"
+    class="absolute left-0 top-0 w-full h-full object-cover"
+  />
+  <div class="absolute inset-0 bg-black/30 group-hover:bg-black/50 transition-colors flex items-center justify-center">
+    <div class="bg-red-600 rounded-full p-4 group-hover:scale-110 transition-transform">
+      <PlaySolid class="w-12 h-12 text-white" />
+    </div>
+  </div>
+  <div class="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4">
+    <p class="text-white text-sm">Click to open in YouTube</p>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- Fixed YouTube Error 153 that prevented video embeds from loading in the dashboard
- Removed modal popup approach and simplified UX to open videos directly in YouTube
- Updated YoutubeEmbed component to display thumbnail with interactive play button overlay

## Changes
- **Dashboard.svelte**: Removed modal and video preview state
- **MediaAdmin.svelte**: Removed click handler on table rows
- **YoutubeEmbed.svelte**: Replaced iframe embed with clickable thumbnail that opens YouTube in new tab

## Why
YouTube actively blocks embedding in Chrome extension pages (Error 153). Instead of using complex workarounds, this provides a cleaner UX where clicking any video thumbnail opens the full video in YouTube.

## Test plan
- [x] Build the extension with `pnpm run dev`
- [x] Open dashboard and verify video thumbnails display correctly
- [x] Click on a video thumbnail and verify it opens YouTube in a new tab
- [x] Verify no Error 153 or other console errors